### PR TITLE
Bump scala-xml and some other dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,10 +4,10 @@ object Dependencies {
 
   object Versions {
     val ivy = "2.4.0"
-    val scalaXml = "1.2.0"
-    val scala212 = "2.12.8"
-    val scala213 = "2.13.0"
-    val scalatest = "3.0.8"
+    val scalaXml = "2.1.0"
+    val scala212 = "2.12.16"
+    val scala213 = "2.13.8"
+    val scalatest = "3.1.4"
     val scala211 = "2.11.11"
     val scalaLibrary = "2.13.0"
     val mavenArtifact = "3.6.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M14-4")
-
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")


### PR DESCRIPTION
Due to some libraries being updated to newer scala-xml, some plugins need it's dependencies being updated too.

This PR bumps scala-xml and some other dependencies as well as SBT.

SBT comes with sbt-coursier so it's plugin was dropped.

Refs:
- https://github.com/aiyanbo/sbt-dependency-updates
- https://github.com/scoverage/sbt-scoverage/issues/439